### PR TITLE
Add goodparts to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 coverage
 npm-debug.log
 .eslintrc*
+config.env

--- a/lib/add_default_values.js
+++ b/lib/add_default_values.js
@@ -5,12 +5,8 @@
 * @return {boolean} - any changes apply to the schema
 */
 var defaultSchema = {
-  email: {
-    type: 'email'
-  },
-  password: {
-    type: 'password'
-  }
+  email: { type: 'email' },
+  password: { type: 'password' }
 };
 
 module.exports = function (schema) {
@@ -19,7 +15,8 @@ module.exports = function (schema) {
     if (!schema.hasOwnProperty(field)) {
       schema[field] = defaultSchema[field];
       anyChanges = true;
-    };
+    }
   });
+
   return anyChanges;
 };

--- a/lib/add_default_values.js
+++ b/lib/add_default_values.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
 * Initialse with the default values the schema if they are not defined Yet
 * Write schema in the file if the default values are added
@@ -11,6 +13,7 @@ var defaultSchema = {
 
 module.exports = function (schema) {
   var anyChanges = false;
+
   Object.keys(defaultSchema).forEach(function (field) {
     if (!schema.hasOwnProperty(field)) {
       schema[field] = defaultSchema[field];

--- a/lib/add_default_values.js
+++ b/lib/add_default_values.js
@@ -15,8 +15,8 @@ var defaultSchema = {
 
 module.exports = function (schema) {
   var anyChanges = false;
-  Object.keys(defaultSchema).forEach(function(field) {
-    if(!schema.hasOwnProperty(field)){
+  Object.keys(defaultSchema).forEach(function (field) {
+    if (!schema.hasOwnProperty(field)) {
       schema[field] = defaultSchema[field];
       anyChanges = true;
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,20 +1,19 @@
 var addDefaultValues = require('./add_default_values.js');
 var loadSchema = require('./load_schema.js');
 var updateSchema = require('./update_schema.js');
-var fs = require('fs');
 
 module.exports = function (server, options, next) {
   if (!options.hasOwnProperty('user_schema_path')) {
     return next('Error: user_schema_path is not defined, please define a user_schema_path');
   }
 
-  loadSchema(options.user_schema_path, function(errorLoad, schema) {
+  loadSchema(options.user_schema_path, function (errorLoad, schema) {
     if (errorLoad) {
       return next(errorLoad);
     }
 
     if (addDefaultValues(schema)) {
-      updateSchema(options.user_schema_path, schema, function(errorUpdateSchema) {
+      updateSchema(options.user_schema_path, schema, function (errorUpdateSchema) {
         return next(errorUpdateSchema);
       });
     } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,24 +1,29 @@
+'use strict';
+
 var addDefaultValues = require('./add_default_values.js');
 var loadSchema = require('./load_schema.js');
 var updateSchema = require('./update_schema.js');
 
 module.exports = function (server, options, next) {
   if (!options.hasOwnProperty('user_schema_path')) {
-    return next('Error: user_schema_path is not defined, please define a user_schema_path');
+    return next(new Error('user_schema_path is not defined'));
   }
 
-  loadSchema(options.user_schema_path, function (errorLoad, schema) {
+  return loadSchema(options.user_schema_path, function (errorLoad, schema) {
     if (errorLoad) {
       return next(errorLoad);
     }
 
-    if (addDefaultValues(schema)) {
-      updateSchema(options.user_schema_path, schema, function (errorUpdateSchema) {
-        return next(errorUpdateSchema);
-      });
-    } else {
+    if (!addDefaultValues(schema)) {
       return next();
     }
+
+    return updateSchema(
+      options.user_schema_path,
+      schema,
+      function (errorUpdateSchema) {
+        return next(errorUpdateSchema);
+      });
   });
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,4 @@ module.exports = function (server, options, next) {
   });
 };
 
-module.exports.attributes = {
-  name: 'Abase'
-};
+module.exports.attributes = { name: 'Abase' };

--- a/lib/load_schema.js
+++ b/lib/load_schema.js
@@ -13,8 +13,11 @@ module.exports = function (schemaPath, cb) {
     try {
       var schema = JSON.parse(data);
     } catch (parseError) {
-        return cb('Error: the schema user file contains unconventianal type, please make sure an schema object is defined');
+      return cb(
+        'Error: the schema user file contains unconventianal type,'
+        + 'please make sure an schema object is defined'
+      );
     }
-    return cb(undefined, schema);
+    return cb(null, schema);
   });
 };

--- a/lib/load_schema.js
+++ b/lib/load_schema.js
@@ -1,17 +1,23 @@
-/**
-* load the shema user
-* @param {sting} schemaPath - the file path of the schema
-* @param {function} cb - callback with error and the schema object
-*/
+'use strict';
+
 var fs = require('fs');
 
+/**
+* load the schema user
+* @param {sting} schemaPath - the file path of the schema
+* @param {function} cb - callback with error and the schema object
+* @returns {void}
+*/
 module.exports = function (schemaPath, cb) {
   fs.readFile(schemaPath, function (err, data) {
+    var schema;
+
     if (err) {
       return cb('Error: sorry impossible to read the file at ' + schemaPath);
     }
+
     try {
-      var schema = JSON.parse(data);
+      schema = JSON.parse(data);
     } catch (parseError) {
       return cb(
         'Error: the schema user file contains unconventianal type,'

--- a/lib/load_schema.js
+++ b/lib/load_schema.js
@@ -18,6 +18,7 @@ module.exports = function (schemaPath, cb) {
         + 'please make sure an schema object is defined'
       );
     }
+
     return cb(null, schema);
   });
 };

--- a/lib/update_schema.js
+++ b/lib/update_schema.js
@@ -1,11 +1,14 @@
-/**
-* Update the schema json file
-* @param {string} user_schema_path, the path of the schema file
-* @param {object} schema - the schema user object
-* @param {function} cb - callback with error
-*/
+'use strict';
 
 var fs = require('fs');
-module.exports = function (user_schema_path, schema, cb) {
-  fs.writeFile(user_schema_path, JSON.stringify(schema), 'utf8', cb);
+
+/**
+* Update the schema json file
+* @param {string} userSchemaPath, the path of the schema file
+* @param {object} schema - the schema user object
+* @param {function} cb - callback with error
+* @returns {void}
+*/
+module.exports = function (userSchemaPath, schema, cb) {
+  fs.writeFile(userSchemaPath, JSON.stringify(schema), 'utf8', cb);
 };

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "scripts": {
     "test": "node_modules/.bin/tape ./test/*.test.js",
-    "lint": "node_modules/.bin/eslint .",
+    "lint": "node_modules/.bin/goodparts .",
     "lint:init": "ln -sf node_modules/goodparts/.eslintrc.js ./.eslintrc.js",
-    "lint:fix": "node_modules/.bin/eslint . --fix",
+    "lint:fix": "node_modules/.bin/goodparts . --fix",
     "coverage": "node_modules/.bin/istanbul cover node_modules/.bin/tape ./test/*.test.js",
     "codecov": "node_modules/.bin/codecov --token=${CODECOV_TOKEN}",
     "postinstall": "npm run lint:init"

--- a/package.json
+++ b/package.json
@@ -26,11 +26,9 @@
   "scripts": {
     "test": "node_modules/.bin/tape ./test/*.test.js",
     "lint": "node_modules/.bin/goodparts .",
-    "lint:init": "ln -sf node_modules/goodparts/.eslintrc.js ./.eslintrc.js",
     "lint:fix": "node_modules/.bin/goodparts . --fix",
     "coverage": "node_modules/.bin/istanbul cover node_modules/.bin/tape ./test/*.test.js",
-    "codecov": "node_modules/.bin/codecov --token=${CODECOV_TOKEN}",
-    "postinstall": "npm run lint:init"
+    "codecov": "node_modules/.bin/codecov --token=${CODECOV_TOKEN}"
   },
   "pre-commit": [
     "lint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "abase2",
-  "version": "1.0.8",
+  "name": "abase",
+  "version": "1.0.0",
   "description": "A simple service to help people manage their personal data in your app.",
   "main": "lib/index.js",
   "repository": {
@@ -18,7 +18,7 @@
     "codecov": "^1.0.1",
     "eslint": "^3.5.0",
     "hapi": "^15.1.0",
-    "goodparts": "^1.0.3",
+    "goodparts": "^1.0.4",
     "istanbul": "^0.4.5",
     "pre-commit": "^1.1.3",
     "tape": "^4.6.0"

--- a/package.json
+++ b/package.json
@@ -15,16 +15,18 @@
   },
   "homepage": "https://github.com/dwyl/abase#readme",
   "devDependencies": {
-    "eslint": "^3.5.0",
+    "goodparts": "^1.0.3",
     "istanbul": "^0.4.5",
     "pre-commit": "^1.1.3",
     "tape": "^4.6.0"
   },
   "scripts": {
     "test": "node_modules/.bin/tape ./test/*.test.js",
-    "lint": "node_modules/.bin/eslint .",
-    "lint:fix": "node_modules/.bin/eslint . --fix",
-    "coverage": "node_modules/.bin/istanbul cover node_modules/.bin/tape ./test/*.test.js"
+    "lint": "node_modules/.bin/goodparts .",
+    "lint:fix": "node_modules/.bin/goodparts . --fix",
+    "lint:init": "ln -sf node_modules/goodparts/.eslintrc.js ./.eslintrc.js",
+    "coverage": "node_modules/.bin/istanbul cover node_modules/.bin/tape ./test/*.test.js",
+    "postinstall": "npm run lint:init"
   },
   "pre-commit": [
     "lint",

--- a/test/add_default_values.test.js
+++ b/test/add_default_values.test.js
@@ -1,16 +1,19 @@
+'use strict';
+
 var tape = require('tape');
 var addDefaultValues = require('../lib/add_default_values.js');
 
 tape('add default values to empty object', function (t) {
   var anyChanges = addDefaultValues({});
+
   t.ok(anyChanges, 'Default values added to the schema');
   t.end();
 });
 
 tape('add email to schema if not defined yet', function (t) {
   var obj = { password: { type: 'password' } };
-
   var anyChanges = addDefaultValues(obj);
+
   t.ok(anyChanges, 'Changes applied to the schema');
   t.ok(obj.hasOwnProperty('email'), 'email added');
   t.end();
@@ -18,8 +21,8 @@ tape('add email to schema if not defined yet', function (t) {
 
 tape('add password to schema if not defined yet', function (t) {
   var obj = { email: { type: 'email' } };
-
   var anyChanges = addDefaultValues(obj);
+
   t.ok(anyChanges, 'Changes applied to the schema');
   t.ok(obj.hasOwnProperty('password'), 'password added');
   t.end();
@@ -30,8 +33,8 @@ tape('do not add default values if they are already defined', function (t) {
     email: { type: 'email' },
     password: { type: 'password' }
   };
-
   var anyChanges = addDefaultValues(obj);
+
   t.ok(!anyChanges, 'No changes applied to the schema');
   t.end();
 });

--- a/test/add_default_values.test.js
+++ b/test/add_default_values.test.js
@@ -8,9 +8,7 @@ tape('add default values to empty object', function (t) {
 });
 
 tape('add email to schema if not defined yet', function (t) {
-  var obj = {
-    password: { type: 'password' }
-  };
+  var obj = { password: { type: 'password' } };
 
   var anyChanges = addDefaultValues(obj);
   t.ok(anyChanges, 'Changes applied to the schema');
@@ -19,9 +17,7 @@ tape('add email to schema if not defined yet', function (t) {
 });
 
 tape('add password to schema if not defined yet', function (t) {
-  var obj = {
-    email: { type: 'email' }
-  };
+  var obj = { email: { type: 'email' } };
 
   var anyChanges = addDefaultValues(obj);
   t.ok(anyChanges, 'Changes applied to the schema');

--- a/test/add_default_values.test.js
+++ b/test/add_default_values.test.js
@@ -9,7 +9,7 @@ tape('add default values to empty object', function (t) {
 
 tape('add email to schema if not defined yet', function (t) {
   var obj = {
-    password: {type: 'password'}
+    password: { type: 'password' }
   };
 
   var anyChanges = addDefaultValues(obj);
@@ -20,7 +20,7 @@ tape('add email to schema if not defined yet', function (t) {
 
 tape('add password to schema if not defined yet', function (t) {
   var obj = {
-    email: {type: 'email'}
+    email: { type: 'email' }
   };
 
   var anyChanges = addDefaultValues(obj);
@@ -31,8 +31,8 @@ tape('add password to schema if not defined yet', function (t) {
 
 tape('do not add default values if they are already defined', function (t) {
   var obj = {
-    email: {type: 'email'},
-    password: {type: 'password'}
+    email: { type: 'email' },
+    password: { type: 'password' }
   };
 
   var anyChanges = addDefaultValues(obj);

--- a/test/helpers/hooks.js
+++ b/test/helpers/hooks.js
@@ -2,6 +2,7 @@
  * Test hooks for tape taken from:
  * https://github.com/substack/tape/issues/59#issuecomment-32808769
  */
+'use strict';
 
 exports.beforeEach = function (_test, handler) {
   return function tapish (name, listener) {

--- a/test/helpers/hooks.js
+++ b/test/helpers/hooks.js
@@ -2,11 +2,10 @@
  * Test hooks for tape taken from:
  * https://github.com/substack/tape/issues/59#issuecomment-32808769
  */
-'use strict';
 
-exports.beforeEach = function beforeEach (test, handler) {
+exports.beforeEach = function (_test, handler) {
   return function tapish (name, listener) {
-    test(name, function (assert) {
+    _test(name, function (assert) {
       var _end = assert.end;
 
       assert.end = function () {
@@ -19,9 +18,9 @@ exports.beforeEach = function beforeEach (test, handler) {
   };
 };
 
-exports.afterEach = function afterEach (test, handler) {
+exports.afterEach = function (_test, handler) {
   return function tapish (name, listener) {
-    test(name, function (assert) {
+    _test(name, function (assert) {
       var _end = assert.end;
 
       assert.end = function () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var fs = require('fs');
 var Hapi = require('hapi');
 var tape = require('tape');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var fs = require('fs');
 var Hapi = require('hapi');
 var tape = require('tape');

--- a/test/load_schema.test.js
+++ b/test/load_schema.test.js
@@ -32,7 +32,9 @@ tape('load the schema', function (t) {
     t.ok(!error, 'no errors');
     t.deepEqual(
       schema,
-      { email: { type: 'email' }, password: { type: 'password' } },
+      {
+        email: { type: 'email' }, password: { type: 'password' }
+      },
       'the schema is loaded properly'
     );
     t.end();

--- a/test/load_schema.test.js
+++ b/test/load_schema.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var tape = require('tape');
 var loadSchema = require('../lib/load_schema.js');
 var path = require('path');
@@ -15,28 +17,32 @@ tape('attempt to load a schema with a wrong path file', function (t) {
 });
 
 tape('the schema is not a json object', function (t) {
-  loadSchema(path.join(__dirname, 'fixtures', 'wrong_schema.json'), function (error) {
-    t.ok(error, 'can\'t parse the content of the schema');
-    t.equal(
-      error,
-      'Error: the schema user file contains unconventianal type,'
-      + 'please make sure an schema object is defined',
-      'error schema parse displayed properly'
-    );
-    t.end();
-  });
+  loadSchema(
+    path.join(__dirname, 'fixtures', 'wrong_schema.json'),
+    function (error) {
+      t.ok(error, 'can\'t parse the content of the schema');
+      t.equal(
+        error,
+        'Error: the schema user file contains unconventianal type,'
+        + 'please make sure an schema object is defined',
+        'error schema parse displayed properly'
+      );
+      t.end();
+    });
 });
 
 tape('load the schema', function (t) {
-  loadSchema(path.join(__dirname, 'fixtures', 'right_schema.json'), function (error, schema) {
-    t.ok(!error, 'no errors');
-    t.deepEqual(
-      schema,
-      {
-        email: { type: 'email' }, password: { type: 'password' }
-      },
-      'the schema is loaded properly'
-    );
-    t.end();
-  });
+  loadSchema(
+    path.join(__dirname, 'fixtures', 'right_schema.json'),
+    function (error, schema) {
+      t.ok(!error, 'no errors');
+      t.deepEqual(
+        schema,
+        {
+          email: { type: 'email' }, password: { type: 'password' }
+        },
+        'the schema is loaded properly'
+      );
+      t.end();
+    });
 });

--- a/test/load_schema.test.js
+++ b/test/load_schema.test.js
@@ -3,17 +3,26 @@ var loadSchema = require('../lib/load_schema.js');
 var path = require('path');
 
 tape('attempt to load a schema with a wrong path file', function (t) {
-  loadSchema('./wrongpathoffile.json', function (error, schema) {
+  loadSchema('./wrongpathoffile.json', function (error) {
     t.ok(error, 'can\'t read a file with a wrong path');
-    t.equal(error, 'Error: sorry impossible to read the file at ./wrongpathoffile.json', 'error message is passed to the callback');
+    t.equal(
+      error,
+      'Error: sorry impossible to read the file at ./wrongpathoffile.json',
+      'error message is passed to the callback'
+    );
     t.end();
   });
 });
 
 tape('the schema is not a json object', function (t) {
-  loadSchema(path.join(__dirname, 'fixtures', 'wrong_schema.json'), function (error, schema) {
+  loadSchema(path.join(__dirname, 'fixtures', 'wrong_schema.json'), function (error) {
     t.ok(error, 'can\'t parse the content of the schema');
-    t.equal(error, 'Error: the schema user file contains unconventianal type, please make sure an schema object is defined', 'error schema parse displayed properly');
+    t.equal(
+      error,
+      'Error: the schema user file contains unconventianal type,'
+      + 'please make sure an schema object is defined',
+      'error schema parse displayed properly'
+    );
     t.end();
   });
 });
@@ -21,7 +30,11 @@ tape('the schema is not a json object', function (t) {
 tape('load the schema', function (t) {
   loadSchema(path.join(__dirname, 'fixtures', 'right_schema.json'), function (error, schema) {
     t.ok(!error, 'no errors');
-    t.deepEqual(schema, {email: {type: "email"}, password: {type: "password"}}, 'the schema is loaded properly');
+    t.deepEqual(
+      schema,
+      { email: { type: 'email' }, password: { type: 'password' } },
+      'the schema is loaded properly'
+    );
     t.end();
   });
 });

--- a/test/update_schema.test.js
+++ b/test/update_schema.test.js
@@ -4,8 +4,9 @@ var path = require('path');
 
 tape('attempt to update a schema with a wrong schema path', function (t) {
   var wrongPath = path.join(__dirname, 'fixtures', 'wrongpath', 'schema.json');
-  updateSchema(wrongPath, {}, function (error, response) {
+  updateSchema(wrongPath, {}, function (error) {
     t.ok(error, 'can\'t write a file with a wrong path');
     t.end();
   });
 });
+

--- a/test/update_schema.test.js
+++ b/test/update_schema.test.js
@@ -1,12 +1,14 @@
+'use strict';
+
 var tape = require('tape');
 var updateSchema = require('../lib/update_schema.js');
 var path = require('path');
 
 tape('attempt to update a schema with a wrong schema path', function (t) {
   var wrongPath = path.join(__dirname, 'fixtures', 'wrongpath', 'schema.json');
+
   updateSchema(wrongPath, {}, function (error) {
     t.ok(error, 'can\'t write a file with a wrong path');
     t.end();
   });
 });
-


### PR DESCRIPTION
#### Changes
- Add goodparts as a dev dependency and remove eslint
- Change `lint:xxx` scripts to use goodparts binary instead of eslint
- Linter errors should be fixed now
- Hack to get goodparts working in atom:
  - Add `lint:init` script to symlink the goodparts `.eslintrc.js` into root
  - **NOTE:** Must be using the global `eslint` package in the atom `linter-eslint` package settings
