### PR TITLE
Hashing Data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: node_js
 node_js:
   - "6"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 script: npm run coverage
 before_script:
   - psql -c 'CREATE DATABASE travis_ci_test;' -U postgres

--- a/lib/config_validator.js
+++ b/lib/config_validator.js
@@ -14,8 +14,10 @@ var fieldSchema = Joi.object()
 ;
 var configSchema = Joi.object().keys({
   table_name: Joi.string().regex(dbNameRegEx).required(), // eslint-disable-line
-  fields: Joi.object().pattern(dbNameRegEx, fieldSchema).required() // eslint-disable-line
-});
+  fields: Joi.object().pattern(dbNameRegEx, fieldSchema).required(), // eslint-disable-line
+  salt_number: Joi.number().integer().min(1) // eslint-disable-line
+})
+  .unknown();
 
 module.exports = function (config) {
   return Joi.assert(config, configSchema);

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -13,26 +13,29 @@ function addToQueue (config) {
   };
 }
 
-function successiveHash (data, hashed, hashQueue, cb) {
-  var toBeHashed = hashQueue.pop();
+function successiveHash (saltNumber, data, cb) {
+  return function hashStep (hashed, hashQueue) {
+    var toBeHashed = hashQueue.pop();
 
-  if (typeof toBeHashed === 'undefined') {
-    return cb(null, hashed);
-  }
-
-  return bcrypt.hash(data[toBeHashed], 10, function (err, hash) {
-    if (err) {
-      return cb(err);
+    if (typeof toBeHashed === 'undefined') {
+      return cb(null, hashed);
     }
-    hashed[toBeHashed] = hash;
 
-    return successiveHash(data, hashed, hashQueue, cb);
-  });
+    return bcrypt.hash(data[toBeHashed], saltNumber, function (err, hash) {
+      if (err) {
+        return cb(err);
+      }
+      hashed[toBeHashed] = hash;
+
+      return hashStep(hashed, hashQueue);
+    });
+  };
 }
 
 module.exports = function (config, data, cb) {
   var hashQueue = Object.keys(data).reduce(addToQueue(config), []);
   var hashed = except(hashQueue, data);
+  var saltNumber = config.salt_number || 10;
 
-  return successiveHash(data, hashed, hashQueue, cb);
+  return successiveHash(saltNumber, data, cb)(hashed, hashQueue);
 };

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -7,7 +7,7 @@ var except = require('./utils').except;
 function addToQueue (config) {
   return function (queue, field) {
     var fieldConfig = config.fields[field];
-    var needsHash = fieldConfig.hash === true || fieldConfig.password === true;
+    var needsHash = fieldConfig.password === true;
 
     return needsHash ? queue.concat(field) : queue;
   };

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var bcrypt = require('bcrypt');
+
+var except = require('./utils').except;
+
+function addToQueue (config) {
+  return function (queue, field) {
+    var fieldConfig = config.fields[field];
+    var needsHash = fieldConfig.hash === true || fieldConfig.password === true;
+
+    return needsHash ? queue.concat(field) : queue;
+  };
+}
+
+function successiveHash (data, hashed, hashQueue, cb) {
+  var toBeHashed = hashQueue.pop();
+
+  if (typeof toBeHashed === 'undefined') {
+    return cb(null, hashed);
+  }
+
+  return bcrypt.hash(data[toBeHashed], 10, function (err, hash) {
+    if (err) {
+      return cb(err);
+    }
+    hashed[toBeHashed] = hash;
+
+    return successiveHash(data, hashed, hashQueue, cb);
+  });
+}
+
+module.exports = function (config, data, cb) {
+  var hashQueue = Object.keys(data).reduce(addToQueue(config), []);
+  var hashed = except(hashQueue, data);
+
+  return successiveHash(data, hashed, hashQueue, cb);
+};

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "coverage"
   ],
   "dependencies": {
+    "bcrypt": "^0.8.7",
     "env2": "^2.1.1",
     "hoek": "^4.1.0",
     "joi": "^9.0.4",

--- a/test/config_validator.test.js
+++ b/test/config_validator.test.js
@@ -39,10 +39,40 @@ test('config validator', function (t) {
       table_name: 'test', // eslint-disable-line
       fields: { email: {
         type: 'string',
-        unknown: 'allowed'
-      } }
+        unknown: 'field'
+      } },
+      unknown: 'config'
     }),
     'no error when extra options unknown'
+  );
+
+  t.end();
+});
+
+test('salt_number', function (t) {
+  t.doesNotThrow(
+    validator({
+      table_name: 'test', // eslint-disable-line
+      fields: { },
+      salt_number: 1 // eslint-disable-line
+    }),
+    '1 min number of rounds'
+  );
+  t.throws(
+    validator({
+      table_name: 'test', // eslint-disable-line
+      fields: { },
+      salt_number: 1.4 // eslint-disable-line
+    }),
+    'salt number must be integer'
+  );
+  t.throws(
+    validator({
+      table_name: 'test', // eslint-disable-line
+      fields: { },
+      salt_number: 0 // eslint-disable-line
+    }),
+    'salt number higher than 0'
   );
 
   t.end();

--- a/test/hash.test.js
+++ b/test/hash.test.js
@@ -6,7 +6,7 @@ var compareSync = require('bcrypt').compareSync;
 var hash = require('../lib/hash.js');
 
 var testConfig = { fields: {
-  secretAnswer: { hash: true },
+  secretAnswer: { password: true },
   password: { password: true },
   email: {}
 } };

--- a/test/hash.test.js
+++ b/test/hash.test.js
@@ -45,11 +45,11 @@ test('needs to be hashed', function (t) {
     t.notEqual(res, testData, 'new object always returned');
     t.ok(
       compareSync(testData.password, res.password),
-      'field tagged password hashed ok'
+      'field tagged password hashed ok default salt number used'
     );
     t.ok(
       compareSync(testData.secretAnswer, res.secretAnswer),
-      'field tagged hash, hashed ok'
+      'other field tagged password hashed ok default salt number used'
     );
 
     t.end();
@@ -72,6 +72,19 @@ test('forcing a bcrypt error with invalid args (won\'t happen)', function (t) {
       },
       'original object not mutated'
     );
+
+    t.end();
+  });
+});
+
+test('custom salt number', function (t) {
+  var saltConfig = {
+    fields: { password: { password: true } },
+    salt_number: 5 // eslint-disable-line
+  };
+
+  hash(saltConfig, { password: 'hash me' }, function (err) {
+    t.notOk(err, 'when providing custom salt number');
 
     t.end();
   });

--- a/test/hash.test.js
+++ b/test/hash.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+var test = require('tape');
+var compareSync = require('bcrypt').compareSync;
+
+var hash = require('../lib/hash.js');
+
+var testConfig = { fields: {
+  secretAnswer: { hash: true },
+  password: { password: true },
+  email: {}
+} };
+
+test('no need to hash, cb instantaneous w/o err but new object', function (t) {
+  var testData = { email: 't@g.com' };
+
+  hash(testConfig, testData, function (err, res) {
+    t.equal(err, null, 'no chance for error creation');
+    t.deepEqual(res, { email: 't@g.com' }, 'object shallowly equal');
+    t.notEqual(res, testData, 'new object always returned');
+
+    t.end();
+  });
+});
+
+test('needs to be hashed', function (t) {
+  var testData = {
+    email: 'no@need.com',
+    password: 'hash me',
+    secretAnswer: 'please'
+  };
+
+  hash(testConfig, testData, function (err, res) {
+    t.notOk(err, 'no error should be produced');
+    t.deepEqual(
+      testData,
+      {
+        email: 'no@need.com',
+        password: 'hash me',
+        secretAnswer: 'please'
+      },
+      'original object not mutated'
+    );
+    t.equal(res.email, testData.email, 'email remains the same');
+    t.notEqual(res, testData, 'new object always returned');
+    t.ok(
+      compareSync(testData.password, res.password),
+      'field tagged password hashed ok'
+    );
+    t.ok(
+      compareSync(testData.secretAnswer, res.secretAnswer),
+      'field tagged hash, hashed ok'
+    );
+
+    t.end();
+  });
+});
+
+test('forcing a bcrypt error with invalid args (won\'t happen)', function (t) {
+  var testData = {
+    password: 'validString',
+    secretAnswer: 42
+  };
+
+  hash(testConfig, testData, function (err) {
+    t.ok(err, 'error created');
+    t.deepEqual(
+      testData,
+      {
+        password: 'validString',
+        secretAnswer: 42
+      },
+      'original object not mutated'
+    );
+
+    t.end();
+  });
+});


### PR DESCRIPTION
## THIS PR

Necessary for password, secret answers etc. Function can be used at layer most appropriate
- Function to take some data and hash asynchronously according to field settings in config.
- Fields can be given password or hash prop set as true to be told to hash.
- New object given back, old not mutated.
- Salt round defaults 10 but customisable with config object

Related: #52
