### PR TITLE
Unit test existing Utils + add shallow copy

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,8 @@ exports.values = function (obj, keys) {
     .map(function (k) { return obj[k] });
 };
 
-exports.except = function (fields, obj) {
+
+function except (fields, obj) {
   var o = {};
 
   Object.keys(obj).forEach(function (k) {
@@ -15,4 +16,11 @@ exports.except = function (fields, obj) {
   });
 
   return o;
+}
+
+
+exports.except = except;
+
+exports.shallowCopy = function (obj) {
+  return except([], obj);
 };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -27,11 +27,25 @@ test('::values w/ chosen order', function (t) {
 });
 
 test('::except', function (t) {
-  t.equal(
+  t.deepEqual(
     _.except(['b'], o),
     { a: 1 },
     'Only "a" prop left'
   );
+
+  t.end();
+});
+
+test('::shallowCopy', function (t) {
+  var n = {
+    a: o,
+    b: 'c'
+  };
+  var copy = _.shallowCopy(n);
+
+  t.deepEqual(copy, n, 'deep equal');
+  t.notEqual(copy, n, 'Not same object');
+  t.equal(copy.a, o, 'Only shallowly copied');
 
   t.end();
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -3,13 +3,35 @@
 var test = require('tape');
 var _ = require('../lib/utils.js');
 
+var o = {
+  a: 1,
+  b: 2
+};
+
 test('::values w/ default keys value', function (t) {
-  var o = {
-    a: 1, b: 2
-  };
   var result = _.values(o);
 
-  t.equal(result[0], o.a, 'Key "a" matches');
-  t.equal(result[1], o.b, 'Key "b" matches');
+  t.ok(result.indexOf(o.a) > -1, 'Key "a"\'s value found');
+  t.ok(result.indexOf(o.b) > -1, 'Key "b"\'s value found');
+  t.end();
+});
+
+test('::values w/ chosen order', function (t) {
+  t.deepEqual(
+    _.values(o, ['b', 'a']),
+    [o.b, o.a],
+    '"b" given back first, "a" second'
+  );
+
+  t.end();
+});
+
+test('::except', function (t) {
+  t.equal(
+    _.except(['b'], o),
+    { a: 1 },
+    'Only "a" prop left'
+  );
+
   t.end();
 });


### PR DESCRIPTION
## THIS PR
- unit test existing
- shallowCopy 
  +Short for except with empty array
  - Obviously can rewrite to make more efficient but ok for now.

Will revisit when more utils added and create a general predicate transform structure over the keys.

Related: #61
