### PR TITLE
Password hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: node_js
 node_js:
   - "6"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 script: npm run coverage
 before_script:
   - psql -c 'CREATE DATABASE travis_ci_test;' -U postgres

--- a/lib/config_validator.js
+++ b/lib/config_validator.js
@@ -14,8 +14,10 @@ var fieldSchema = Joi.object()
 ;
 var configSchema = Joi.object().keys({
   table_name: Joi.string().regex(dbNameRegEx).required(), // eslint-disable-line
-  fields: Joi.object().pattern(dbNameRegEx, fieldSchema).required() // eslint-disable-line
-});
+  fields: Joi.object().pattern(dbNameRegEx, fieldSchema).required(), // eslint-disable-line
+  salt_number: Joi.number().integer().min(1) // eslint-disable-line
+})
+  .unknown();
 
 module.exports = function (config) {
   return Joi.assert(config, configSchema);

--- a/lib/create_table_map.js
+++ b/lib/create_table_map.js
@@ -4,8 +4,13 @@ var mapObj = {
   number: function (opts) {
     return opts.integer ? 'BIGINT' : 'DOUBLE PRECISION';
   },
-  string: function (opts) {
+  string: function (opts, name) {
     var length = opts.max || 80;
+    var willBeHashed = name === 'password';
+
+    if (willBeHashed) {
+      length = 60; // http://stackoverflow.com/questions/5881169/what-column-type-length-should-i-use-for-storing-a-bcrypt-hashed-password-in-a-d
+    }
 
     return 'VARCHAR(' + length + ')';
   },
@@ -20,7 +25,7 @@ var mapObj = {
 function mapper (name, type, options) {
   var opts = options || {};
 
-  return name + ' ' + mapObj[type](opts);
+  return name + ' ' + mapObj[type](opts, name);
 }
 
 module.exports = mapper;

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,15 +1,39 @@
 'use strict';
 
+var bcrypt = require('bcrypt');
+
 var sqlGen = require('./sql_gen.js');
 var configValidator = require('./config_validator.js');
+var utils = require('./utils.js');
 
-var methods = { init: function (client, config, _, cb) {
-  configValidator(config);
+var methods = {
+  init: function (client, config, _, cb) {
+    configValidator(config);
 
-  return client.query(sqlGen.init(config), cb);
-} };
+    return client.query(sqlGen.init(config), cb);
+  },
+  insert: function (client, config, options, cb) {
+    var passwordValue = options.fields.password;
+    var saltNumber = config.salt_number || 10;
+    var tableName = config.table_name;
+    var makeQuery = function (opts) {
+      var args = sqlGen.insert(tableName, opts).concat([cb]);
 
-['select', 'update', 'delete', 'insert'].forEach(function (method) {
+      return client.query.apply(client, args);
+    };
+
+    return bcrypt.hash(passwordValue, saltNumber, function (_, hash) {
+      var optionsCopy = utils.shallowCopy(options);
+
+      optionsCopy.fields = utils.shallowCopy(optionsCopy.fields);
+      optionsCopy.fields.password = hash;
+
+      return makeQuery(optionsCopy);
+    });
+  }
+};
+
+['select', 'update', 'delete'].forEach(function (method) {
   methods[method] = function (client, config, options, cb) {
     var tableName = config.table_name;
     var args = sqlGen[method](tableName, options).concat([cb]);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "coverage"
   ],
   "dependencies": {
+    "bcrypt": "^0.8.7",
     "env2": "^2.1.1",
     "hoek": "^4.1.0",
     "joi": "^9.0.4",

--- a/test/config_validator.test.js
+++ b/test/config_validator.test.js
@@ -39,10 +39,40 @@ test('config validator', function (t) {
       table_name: 'test', // eslint-disable-line
       fields: { email: {
         type: 'string',
-        unknown: 'allowed'
-      } }
+        unknown: 'field'
+      } },
+      unknown: 'config'
     }),
     'no error when extra options unknown'
+  );
+
+  t.end();
+});
+
+test('salt_number', function (t) {
+  t.doesNotThrow(
+    validator({
+      table_name: 'test', // eslint-disable-line
+      fields: { },
+      salt_number: 1 // eslint-disable-line
+    }),
+    '1 min number of rounds'
+  );
+  t.throws(
+    validator({
+      table_name: 'test', // eslint-disable-line
+      fields: { },
+      salt_number: 1.4 // eslint-disable-line
+    }),
+    'salt number must be integer'
+  );
+  t.throws(
+    validator({
+      table_name: 'test', // eslint-disable-line
+      fields: { },
+      salt_number: 0 // eslint-disable-line
+    }),
+    'salt number higher than 0'
   );
 
   t.end();

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var test = require('tape');
+var bcrypt = require('bcrypt');
 
 var client = require('./test_pg_client.js');
 var db = require('../lib/db.js');
@@ -9,7 +10,8 @@ var schema = require('./example_schema.js');
 var testInsert = {
   email: 'test@gmail.com',
   dob: '2001-09-27',
-  username: 'test'
+  username: 'test',
+  password: 'hash me'
 };
 
 test('init test client', function (t) {
@@ -39,33 +41,69 @@ test('db.init', function (t) {
 
 
 test('db.insert & default select w custom where', function (t) {
-  db.insert(client, schema, { fields: testInsert })
-    .then(function () {
-      return db.select(client, schema, { where: { dob: '2001-09-27' } });
-    })
-    .then(function (res) {
-      t.equal(
-        res.rows[0].email,
-        testInsert.email,
-        'email correct'
-      );
-      t.equal(
-        res.rows[0].username,
-        testInsert.username,
-        'username correct'
-      );
-      t.equal(
-        res.rows[0].dob.toLocaleDateString('GMT'),
-        new Date(testInsert.dob).toLocaleDateString('GMT'),
-        'get same date back, though now a date object'
-      );
-      t.end();
-    })
-    .catch(function (err) {
-      t.fail(err);
-      t.end();
-    })
-  ;
+  db.insert(client, schema, { fields: testInsert }, function () {
+    return db.select(client, schema, { where: { dob: '2001-09-27' } })
+      .then(function (res) {
+        t.equal(
+          res.rows[0].email,
+          testInsert.email,
+          'email correct'
+        );
+        t.equal(
+          res.rows[0].username,
+          testInsert.username,
+          'username correct'
+        );
+        t.ok(
+          bcrypt.compareSync(testInsert.password, res.rows[0].password),
+          'password hashed correctly'
+        );
+        t.equal(
+          res.rows[0].dob.toLocaleDateString('GMT'),
+          new Date(testInsert.dob).toLocaleDateString('GMT'),
+          'get same date back, though now a date object'
+        );
+        t.end();
+      })
+      .catch(function (err) {
+        t.fail(err);
+        t.end();
+      })
+    ;
+  });
+});
+
+test('db.insert & default select w custom where', function (t) {
+  db.insert(client, schema, { fields: testInsert }, function () {
+    return db.select(client, schema, { where: { dob: '2001-09-27' } })
+      .then(function (res) {
+        t.equal(
+          res.rows[0].email,
+          testInsert.email,
+          'email correct'
+        );
+        t.equal(
+          res.rows[0].username,
+          testInsert.username,
+          'username correct'
+        );
+        t.ok(
+          bcrypt.compareSync(testInsert.password, res.rows[0].password),
+          'password hashed correctly'
+        );
+        t.equal(
+          res.rows[0].dob.toLocaleDateString('GMT'),
+          new Date(testInsert.dob).toLocaleDateString('GMT'),
+          'get same date back, though now a date object'
+        );
+        t.end();
+      })
+      .catch(function (err) {
+        t.fail(err);
+        t.end();
+      })
+    ;
+  });
 });
 
 test('db.update w where & custom select w default where', function (t) {

--- a/test/example_schema.js
+++ b/test/example_schema.js
@@ -12,6 +12,11 @@ module.exports = {
       min: 3,
       max: 20
     },
+    password: {
+      type: 'string',
+      min: 5,
+      max: 20
+    },
     dob: { type: 'date' }
   }
 };

--- a/test/sql_gen.test.js
+++ b/test/sql_gen.test.js
@@ -20,9 +20,10 @@ tape('::init - generate SQL to create a table if none exists', function (t) {
     'CREATE TABLE IF NOT EXISTS "user_data" ('
     + 'email VARCHAR(80), '
     + 'username VARCHAR(20), '
+    + 'password VARCHAR(60), '
     + 'dob DATE'
     + ')',
-    'Create table query generation from config object'
+    'Create table query generation from config object, pw length overwritten'
   );
   t.end();
 });


### PR DESCRIPTION
## THIS PR

Assumes password field exists when inserting new user data. Hashes the password field entry with bcrypt. #52

I feel #58 is a much better approach as this way to hardcoded for my liking and going against the flow of things but this is the MVP solution

Integration branch #64 has used the old solution.

Note the hashing on inserts has meant that promises aren't returned from db.insert so the cb method must be used here unless we want to promisify bcrypt.
